### PR TITLE
feat: Add hybrid search functionality with Reciprocal Rank Fusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.2] - 2026-05-29
+
+### Added
+- **Hybrid search tool** (`hybrid_search`): Combines vector similarity and full-text keyword search using Cosmos DB's Reciprocal Rank Fusion (RRF) ranking. Requires both a vector index and a full-text index on the target container (issue #89).
+- Added `hybrid_search` to the web testing UI dropdown.
+
+### Changed
+- Default `topN`/`n` for `text_search`, `vector_search`, and `hybrid_search` is now 10 (parameter is optional; existing callers unaffected).
+- Updated NuGet dependencies:
+  - ModelContextProtocol.AspNetCore 0.3.0-preview.4 → 1.3.0
+  - Microsoft.Azure.Cosmos 3.53.0 → 3.60.0
+  - Azure.Identity 1.12.0 → 1.21.0
+  - Azure.AI.OpenAI 2.0.0 → 2.1.0
+  - OpenAI 2.0.0 → 2.1.0
+  - Microsoft.AspNetCore.Authentication.JwtBearer 9.0.0 → 9.0.16
+  - Microsoft.IdentityModel.JsonWebTokens 8.1.2 → 8.18.0
+  - Microsoft.IdentityModel.Protocols.OpenIdConnect 8.1.2 → 8.18.0
+  - Microsoft.IdentityModel.Tokens 8.1.2 → 8.18.0
+  - System.IdentityModel.Tokens.Jwt 8.1.2 → 8.18.0
+  - Microsoft.NET.Test.Sdk 17.8.0 → 18.5.1
+  - Microsoft.AspNetCore.Mvc.Testing 9.0.0 → 9.0.16
+  - FluentAssertions 6.12.0 → 8.10.0
 
 ## [1.1.1] - 2026-05-20
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Azure Cosmos DB MCP Toolkit
 
-A Model Context Protocol (MCP) server that enables AI agents to interact with Azure Cosmos DB through natural language queries. Features enterprise-grade security with Azure Entra ID authentication, document operations, vector search, and schema discovery.
+A Model Context Protocol (MCP) server that enables AI agents to interact with Azure Cosmos DB through natural language queries. Features enterprise-grade security with Azure Entra ID authentication, document operations, vector search, hybrid search, and schema discovery.
 
 ## Prerequisites
 
 - Azure subscription ([Free account](https://azure.microsoft.com/free/))
 - **Azure Cosmos DB account** ([Create account](https://learn.microsoft.com/azure/cosmos-db/nosql/quickstart-portal))
-- **Embedding Service** (one of the following for vector search):
+- **Embedding Service** (one of the following for vector search and hybrid search):
   - **Azure AI Services (Cognitive Services)** with embedding model ([Create](https://learn.microsoft.com/azure/ai-services/what-are-ai-services))
   - **Azure AI Foundry** with embedding model ([Create](https://learn.microsoft.com/azure/ai/foundry/how-to/create-projects))
   - **OpenAI API** with API key ([Get API key](https://platform.openai.com/api-keys))
@@ -22,8 +22,8 @@ A Model Context Protocol (MCP) server that enables AI agents to interact with Az
 This toolkit provides:
 
 - **Secure MCP Server**: JWT-authenticated endpoint for AI agents
-- **Azure Cosmos DB Integration**: Full CRUD operations, vector search, and schema discovery
-- **Azure AI Services Integration**: Automatic embeddings and vector search support
+- **Azure Cosmos DB Integration**: Full CRUD operations, vector search, hybrid search, and schema discovery
+- **Azure AI Services Integration**: Automatic embeddings for vector and hybrid search support
 - **Enterprise Security**: Azure Entra ID, Managed Identity, RBAC
 - **Production Ready**: Container Apps hosting with auto-scaling
 - **Local Development**: Docker Compose and .NET dev options
@@ -39,6 +39,7 @@ This toolkit provides:
 | `find_document_by_id` | Find a document by its id |
 | `text_search` | Search for documents where a property contains a search phrase |
 | `vector_search` | Perform vector search using Azure OpenAI embeddings |
+| `hybrid_search` | Perform hybrid search combining vector similarity and full-text keyword search using Reciprocal Rank Fusion (RRF) |
 
 ## Project Structure
 

--- a/docs/WEB-TESTING-GUIDE.md
+++ b/docs/WEB-TESTING-GUIDE.md
@@ -97,7 +97,8 @@ Your Client ID is created automatically during deployment. Find it in:
 4. **`find_document_by_id`** - Find a specific document by ID
 5. **`text_search`** - Full-text search within documents
 6. **`vector_search`** - Semantic search using AI embeddings
-7. **`get_approximate_schema`** - Analyze document structure
+7. **`hybrid_search`** - Hybrid search combining vector similarity and full-text keyword search using RRF ranking
+8. **`get_approximate_schema`** - Analyze document structure
 
 ### Interactive Testing
 

--- a/src/AzureCosmosDB.MCP.Toolkit/AzureCosmosDB.MCP.Toolkit.csproj
+++ b/src/AzureCosmosDB.MCP.Toolkit/AzureCosmosDB.MCP.Toolkit.csproj
@@ -7,7 +7,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <IsPackable>true</IsPackable>
     <PackageId>AzureCosmosDB.MCP.Toolkit</PackageId>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.1.2</VersionPrefix>
     <Authors>Azure Cosmos DB Team</Authors>
     <Company>Microsoft</Company>
     <Product>Azure Cosmos DB MCP Toolkit</Product>
@@ -23,17 +23,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.3.0-preview.4" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.53.0" />
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.60.0" />
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Azure.AI.OpenAI" Version="2.0.0" />
-    <PackageReference Include="OpenAI" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.1.2" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.1.2" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.1.2" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.1.2" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageReference Include="OpenAI" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.16" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.18.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.18.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
   </ItemGroup>
 
 </Project>

--- a/src/AzureCosmosDB.MCP.Toolkit/Controllers/MCPProtocolController.cs
+++ b/src/AzureCosmosDB.MCP.Toolkit/Controllers/MCPProtocolController.cs
@@ -192,9 +192,9 @@ public class MCPProtocolController : ControllerBase
                                             containerId = new { type = "string", description = "Container id to query", maxLength = 256 },
                                             property = new { type = "string", description = "Document property to search", maxLength = 256 },
                                             searchPhrase = new { type = "string", description = "Search term to look for", maxLength = 2048 },
-                                            n = new { type = "integer", description = "Number of documents to return (1-20)", minimum = 1, maximum = 20 }
+                                            n = new { type = "integer", description = "Number of documents to return (1-20, default 10)", minimum = 1, maximum = 20, @default = 10 }
                                         },
-                                        required = new string[] { "databaseId", "containerId", "property", "searchPhrase", "n" },
+                                        required = new string[] { "databaseId", "containerId", "property", "searchPhrase" },
                                         additionalProperties = false
                                     }
                                 },
@@ -236,9 +236,27 @@ public class MCPProtocolController : ControllerBase
                                             searchText = new { type = "string", description = "Text to search for semantically similar content", maxLength = 2048 },
                                             vectorProperty = new { type = "string", description = "Property name where vector embeddings are stored", maxLength = 256 },
                                             selectProperties = new { type = "string", description = "Comma-separated list of specific properties to project in results", maxLength = 512 },
-                                            topN = new { type = "integer", description = "Number of documents to return (1-50)", minimum = 1, maximum = 50 }
+                                            topN = new { type = "integer", description = "Number of documents to return (1-50, default 10)", minimum = 1, maximum = 50, @default = 10 }
                                         },
-                                        required = new string[] { "databaseId", "containerId", "searchText", "vectorProperty", "selectProperties", "topN" },
+                                        required = new string[] { "databaseId", "containerId", "searchText", "vectorProperty", "selectProperties" },
+                                        additionalProperties = false
+                                    }
+                                },
+                                new { 
+                                    name = "hybrid_search", 
+                                    description = "Performs hybrid search combining vector similarity and full-text search using Reciprocal Rank Fusion (RRF). Requires both a vector index and a full-text index on the container.",
+                                    inputSchema = new {
+                                        type = "object",
+                                        properties = new {
+                                            databaseId = new { type = "string", description = "Database id containing the container", maxLength = 256 },
+                                            containerId = new { type = "string", description = "Container id to query", maxLength = 256 },
+                                            searchText = new { type = "string", description = "Text to search for using both semantic similarity and keyword matching", maxLength = 2048 },
+                                            textProperty = new { type = "string", description = "Property name that has a full-text index for keyword search", maxLength = 256 },
+                                            vectorProperty = new { type = "string", description = "Property name where vector embeddings are stored", maxLength = 256 },
+                                            selectProperties = new { type = "string", description = "Comma-separated list of specific properties to project in results", maxLength = 512 },
+                                            topN = new { type = "integer", description = "Number of documents to return (1-50, default 10)", minimum = 1, maximum = 50, @default = 10 }
+                                        },
+                                        required = new string[] { "databaseId", "containerId", "searchText", "textProperty", "vectorProperty", "selectProperties" },
                                         additionalProperties = false
                                     }
                                 }
@@ -406,7 +424,7 @@ public class MCPProtocolController : ControllerBase
                 GetStringArg(args, "containerId"),
                 GetStringArg(args, "property"),
                 GetStringArg(args, "searchPhrase"),
-                GetRequiredIntArg(args, "n"),
+                GetOptionalIntArg(args, "n", 10),
                 cancellationToken),
             "find_document_by_id" => await _cosmosDbTools.FindDocumentByID(
                 GetStringArg(args, "databaseId"),
@@ -423,7 +441,16 @@ public class MCPProtocolController : ControllerBase
                 GetStringArg(args, "searchText"),
                 GetStringArg(args, "vectorProperty"),
                 GetStringArg(args, "selectProperties"),
-                GetRequiredIntArg(args, "topN"),
+                GetOptionalIntArg(args, "topN", 10),
+                cancellationToken),
+            "hybrid_search" => await _cosmosDbTools.HybridSearch(
+                GetStringArg(args, "databaseId"),
+                GetStringArg(args, "containerId"),
+                GetStringArg(args, "searchText"),
+                GetStringArg(args, "textProperty"),
+                GetStringArg(args, "vectorProperty"),
+                GetStringArg(args, "selectProperties"),
+                GetOptionalIntArg(args, "topN", 10),
                 cancellationToken),
             _ => throw new ArgumentException($"Unknown tool: {toolName}")
         };
@@ -447,6 +474,21 @@ public class MCPProtocolController : ControllerBase
             return parsedValue;
 
         throw new ArgumentException($"Parameter '{key}' must be a valid integer");
+    }
+
+    private static int GetOptionalIntArg(Dictionary<string, object> args, string key, int defaultValue)
+    {
+        if (!args.TryGetValue(key, out var value))
+        {
+            return defaultValue;
+        }
+
+        if (value is int intValue)
+            return intValue;
+        if (int.TryParse(value?.ToString(), out var parsedValue))
+            return parsedValue;
+
+        return defaultValue;
     }
     
     [HttpGet("debug")]

--- a/src/AzureCosmosDB.MCP.Toolkit/Program.cs
+++ b/src/AzureCosmosDB.MCP.Toolkit/Program.cs
@@ -554,7 +554,7 @@ public static class CosmosDbTools
         [Description("Container id to query")] string containerId,
         [Description("Document property to search, e.g. name or profile.name")] string property,
         [Description("Search term to look for within the property")] string searchPhrase,
-        [Description("Number of documents to return (1-20)")] int n)
+        [Description("Number of documents to return (1-20, default 10)")] int n = 10)
     {
         try
         {
@@ -794,7 +794,7 @@ public static class CosmosDbTools
         [Description("Text to search for semantically similar content")] string searchText,
         [Description("Property name where vector embeddings are stored, e.g. 'vector' or 'embeddings'")] string vectorProperty,
         [Description("Comma-separated list of specific properties to project in results, e.g. 'id,title,content'. Cannot use '*' wildcard.")] string selectProperties,
-        [Description("Number of documents to return (1-50)")] int topN)
+        [Description("Number of documents to return (1-50, default 10)")] int topN = 10)
     {
         try
         {
@@ -908,6 +908,162 @@ public static class CosmosDbTools
             var queryDefinition = new QueryDefinition(queryText)
                 .WithParameter("@topN", topN)
                 .WithParameter("@embedding", embedding);
+
+            var iterator = container.GetItemQueryIterator<dynamic>(
+                queryDefinition,
+                requestOptions: new QueryRequestOptions { MaxItemCount = topN }
+            );
+
+            var results = new List<string>();
+            while (iterator.HasMoreResults && results.Count < topN)
+            {
+                var page = await iterator.ReadNextAsync();
+                foreach (var doc in page)
+                {
+                    results.Add(doc?.ToString() ?? "{}");
+                    if (results.Count >= topN) break;
+                }
+            }
+
+            var jsonArray = "[" + string.Join(",", results) + "]";
+            return jsonArray;
+        }
+        catch (CosmosException cex)
+        {
+            return JsonSerializer.Serialize(new { error = cex.Message, statusCode = (int)cex.StatusCode });
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new { error = ex.Message });
+        }
+    }
+
+    [McpServerTool, Description("Performs hybrid search combining vector similarity and full-text keyword search using Reciprocal Rank Fusion (RRF). Requires both a vector index and a full-text index on the container.")]
+    public static async Task<string> HybridSearch(
+        [Description("Database id containing the container")] string databaseId,
+        [Description("Container id to query")] string containerId,
+        [Description("Text to search for using both semantic similarity and keyword matching")] string searchText,
+        [Description("Property name that has a full-text index for keyword search, e.g. 'text' or 'content'")] string textProperty,
+        [Description("Property name where vector embeddings are stored, e.g. 'vector' or 'embeddings'")] string vectorProperty,
+        [Description("Comma-separated list of specific properties to project in results, e.g. 'id,title,content'. Cannot use '*' wildcard.")] string selectProperties,
+        [Description("Number of documents to return (1-50, default 10)")] int topN = 10)
+    {
+        try
+        {
+            // Validate environment variables
+            var cosmosEndpoint = Environment.GetEnvironmentVariable("COSMOS_ENDPOINT");
+            var openaiEndpoint = Environment.GetEnvironmentVariable("OPENAI_ENDPOINT");
+            var embeddingDeployment = Environment.GetEnvironmentVariable("OPENAI_EMBEDDING_DEPLOYMENT");
+
+            if (string.IsNullOrWhiteSpace(cosmosEndpoint))
+            {
+                return JsonSerializer.Serialize(new { error = "Missing required environment variable COSMOS_ENDPOINT." });
+            }
+            if (string.IsNullOrWhiteSpace(openaiEndpoint))
+            {
+                return JsonSerializer.Serialize(new { error = "Missing required environment variable OPENAI_ENDPOINT." });
+            }
+            if (string.IsNullOrWhiteSpace(embeddingDeployment))
+            {
+                return JsonSerializer.Serialize(new { error = "Missing required environment variable OPENAI_EMBEDDING_DEPLOYMENT." });
+            }
+
+            // Validate parameters
+            if (string.IsNullOrWhiteSpace(databaseId) || string.IsNullOrWhiteSpace(containerId))
+            {
+                return JsonSerializer.Serialize(new { error = "Parameters 'databaseId' and 'containerId' are required." });
+            }
+            if (string.IsNullOrWhiteSpace(searchText))
+            {
+                return JsonSerializer.Serialize(new { error = "Parameter 'searchText' is required." });
+            }
+            if (string.IsNullOrWhiteSpace(textProperty))
+            {
+                return JsonSerializer.Serialize(new { error = "Parameter 'textProperty' is required." });
+            }
+            if (string.IsNullOrWhiteSpace(vectorProperty))
+            {
+                return JsonSerializer.Serialize(new { error = "Parameter 'vectorProperty' is required." });
+            }
+            if (string.IsNullOrWhiteSpace(selectProperties))
+            {
+                return JsonSerializer.Serialize(new { error = "Parameter 'selectProperties' is required." });
+            }
+            if (topN < 1 || topN > 50)
+            {
+                return JsonSerializer.Serialize(new { error = "Parameter 'topN' must be a whole number between 1 and 50." });
+            }
+
+            // Validate that selectProperties doesn't contain wildcard
+            if (selectProperties.Trim() == "*" || selectProperties.Contains("*"))
+            {
+                return JsonSerializer.Serialize(new { error = "Parameter 'selectProperties' cannot contain '*' wildcard. Please specify explicit property names separated by commas." });
+            }
+
+            // Validate property names
+            var propPattern = new Regex(@"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$");
+            
+            if (!propPattern.IsMatch(vectorProperty))
+            {
+                return JsonSerializer.Serialize(new { error = "Invalid vectorProperty name. Use dot notation with letters, digits, and underscores only (e.g., 'vector' or 'embeddings')." });
+            }
+
+            if (!propPattern.IsMatch(textProperty))
+            {
+                return JsonSerializer.Serialize(new { error = "Invalid textProperty name. Use dot notation with letters, digits, and underscores only (e.g., 'text' or 'content')." });
+            }
+
+            var properties = selectProperties.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                .Select(p => p.Trim())
+                .ToArray();
+            
+            foreach (var prop in properties)
+            {
+                if (!propPattern.IsMatch(prop))
+                {
+                    return JsonSerializer.Serialize(new { error = $"Invalid property name '{prop}' in selectProperties. Use dot notation with letters, digits, and underscores only (e.g., 'id', 'title', 'metadata.author')." });
+                }
+            }
+
+            var credential = new DefaultAzureCredential();
+
+            // Generate embedding using the configured embedding service
+            float[] embedding;
+            try
+            {
+                if (AppState.Configuration == null)
+                {
+                    return JsonSerializer.Serialize(new { error = "Application configuration not initialized." });
+                }
+                
+                var embeddingClient = EmbeddingClientFactory.CreateEmbeddingClient(AppState.Configuration);
+                embedding = await embeddingClient.GenerateEmbeddingAsync(searchText, embeddingDeployment);
+            }
+            catch (Exception ex)
+            {
+                return JsonSerializer.Serialize(new { error = $"Failed to generate embedding: {ex.Message}" });
+            }
+
+            // Perform hybrid search in Cosmos DB
+            using var cosmosClient = new CosmosClient(cosmosEndpoint, credential, new CosmosClientOptions
+            {
+                ApplicationName = "AzureCosmosDBMCP"
+            });
+
+            var container = cosmosClient.GetContainer(databaseId, containerId);
+
+            var selectClause = string.Join(", ", properties.Select(p => $"c.{p}"));
+
+            // Hybrid search query using RRF to combine vector and full-text scores
+            var queryText = $@"
+                SELECT TOP @topN {selectClause}
+                FROM c
+                ORDER BY RANK RRF(VectorDistance(c.{vectorProperty}, @embedding), FullTextScore(c.{textProperty}, @searchText))";
+
+            var queryDefinition = new QueryDefinition(queryText)
+                .WithParameter("@topN", topN)
+                .WithParameter("@embedding", embedding)
+                .WithParameter("@searchText", searchText);
 
             var iterator = container.GetItemQueryIterator<dynamic>(
                 queryDefinition,

--- a/src/AzureCosmosDB.MCP.Toolkit/Services/CosmosDbToolsService.cs
+++ b/src/AzureCosmosDB.MCP.Toolkit/Services/CosmosDbToolsService.cs
@@ -214,7 +214,7 @@ public class CosmosDbToolsService
         }
     }
 
-    public async Task<object> TextSearch(string databaseId, string containerId, string property, string searchPhrase, int n, CancellationToken cancellationToken = default)
+    public async Task<object> TextSearch(string databaseId, string containerId, string property, string searchPhrase, int n = 10, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -279,7 +279,7 @@ public class CosmosDbToolsService
         }
     }
 
-    public async Task<object> VectorSearch(string databaseId, string containerId, string searchText, string vectorProperty, string selectProperties, int topN, CancellationToken cancellationToken = default)
+    public async Task<object> VectorSearch(string databaseId, string containerId, string searchText, string vectorProperty, string selectProperties, int topN = 10, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -432,6 +432,170 @@ public class CosmosDbToolsService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error in vector search");
+            return new { error = ex.Message };
+        }
+    }
+
+    public async Task<object> HybridSearch(string databaseId, string containerId, string searchText, string textProperty, string vectorProperty, string selectProperties, int topN = 10, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            // Validate parameters
+            ValidateRequiredParameter(databaseId, nameof(databaseId));
+            ValidateRequiredParameter(containerId, nameof(containerId));
+            ValidateRequiredParameter(searchText, nameof(searchText));
+            ValidateRequiredParameter(textProperty, nameof(textProperty));
+            ValidateRequiredParameter(vectorProperty, nameof(vectorProperty));
+            ValidateRequiredParameter(selectProperties, nameof(selectProperties));
+            
+            if (topN < 1 || topN > 50)
+            {
+                return new { error = "Parameter 'topN' must be a whole number between 1 and 50." };
+            }
+
+            if (selectProperties.Trim() == "*" || selectProperties.Contains("*"))
+            {
+                return new { error = "Parameter 'selectProperties' cannot contain '*' wildcard. Please specify explicit property names separated by commas." };
+            }
+
+            var propPattern = new Regex(@"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$");
+            
+            if (!propPattern.IsMatch(vectorProperty))
+            {
+                return new { error = "Invalid vectorProperty name. Use dot notation with letters, digits, and underscores only (e.g., 'vector' or 'embeddings')." };
+            }
+
+            if (!propPattern.IsMatch(textProperty))
+            {
+                return new { error = "Invalid textProperty name. Use dot notation with letters, digits, and underscores only (e.g., 'text' or 'content')." };
+            }
+
+            var properties = selectProperties.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                .Select(p => p.Trim())
+                .ToArray();
+            
+            foreach (var prop in properties)
+            {
+                if (!propPattern.IsMatch(prop))
+                {
+                    return new { error = $"Invalid property name '{prop}' in selectProperties. Use dot notation with letters, digits, and underscores only (e.g., 'id', 'title', 'metadata.author')." };
+                }
+            }
+
+            _logger.LogInformation("Hybrid search for '{SearchText}' in {DatabaseId}/{ContainerId}", searchText, databaseId, containerId);
+
+            // Generate embedding using the appropriate embedding service
+            // (Azure AI Services, OpenAI native, or Azure AI Foundry)
+            float[] embedding;
+            try
+            {
+                _logger.LogInformation("Creating embedding client for hybrid search embedding generation");
+
+                var configuredApiKey = _configuration["OPENAI_API_KEY"]
+                    ?? Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+                var authMode = string.IsNullOrWhiteSpace(configuredApiKey) ? "azure-credential" : "api-key";
+                _logger.LogInformation("Embedding authentication mode: {AuthMode}", authMode);
+                
+                var embeddingClient = EmbeddingClientFactory.CreateEmbeddingClient(_configuration, _logger);
+                
+                var embeddingDeployment = _configuration["OPENAI_EMBEDDING_DEPLOYMENT"] 
+                    ?? Environment.GetEnvironmentVariable("OPENAI_EMBEDDING_DEPLOYMENT");
+                
+                if (string.IsNullOrWhiteSpace(embeddingDeployment))
+                {
+                    return new { error = "Missing required environment variable OPENAI_EMBEDDING_DEPLOYMENT." };
+                }
+                
+                var embeddingDimensionsStr = _configuration["OPENAI_EMBEDDING_DIMENSIONS"] 
+                    ?? Environment.GetEnvironmentVariable("OPENAI_EMBEDDING_DIMENSIONS");
+
+                int? embeddingDimensions = null;
+                if (!string.IsNullOrWhiteSpace(embeddingDimensionsStr) && int.TryParse(embeddingDimensionsStr, out int parsedDimensions) && parsedDimensions > 0)
+                {
+                    embeddingDimensions = parsedDimensions;
+                }
+                
+                _logger.LogInformation("Generating embedding for deployment: {Deployment}{DimensionsInfo}", 
+                    embeddingDeployment,
+                    embeddingDimensions.HasValue ? $" with {embeddingDimensions.Value} dimensions" : "");
+                
+                embedding = await embeddingClient.GenerateEmbeddingAsync(searchText, embeddingDeployment, cancellationToken);
+                _logger.LogInformation("Generated embedding with {Dimensions} dimensions", embedding.Length);
+            }
+            catch (RequestFailedException ex) when (ex.Status == 401 || ex.Status == 403)
+            {
+                var configuredApiKey = _configuration["OPENAI_API_KEY"]
+                    ?? Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+                var usingApiKey = !string.IsNullOrWhiteSpace(configuredApiKey);
+
+                var hint = usingApiKey
+                    ? "OPENAI_API_KEY is configured. Verify the key matches OPENAI_ENDPOINT and has permission to use OPENAI_EMBEDDING_DEPLOYMENT."
+                    : "OPENAI_API_KEY is not configured. The service is using DefaultAzureCredential. Ensure the runtime identity has OpenAI data-plane access (for example, Cognitive Services OpenAI User) on the target resource.";
+
+                _logger.LogError(ex, "Embedding authorization failed with status {StatusCode}. Hint: {Hint}", ex.Status, hint);
+                return new
+                {
+                    error = $"Failed to generate embedding: {ex.Message}",
+                    statusCode = ex.Status,
+                    hint
+                };
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to generate embedding for hybrid search");
+                return new { error = $"Failed to generate embedding: {ex.Message}" };
+            }
+
+            var container = _cosmosClient.GetContainer(databaseId, containerId);
+
+            var selectClause = string.Join(", ", properties.Select(p => $"c.{p}"));
+
+            var queryText = $@"
+                SELECT TOP @topN {selectClause}
+                FROM c
+                ORDER BY RANK RRF(VectorDistance(c.{vectorProperty}, @embedding), FullTextScore(c.{textProperty}, @searchText))";
+
+            var queryDefinition = new QueryDefinition(queryText)
+                .WithParameter("@topN", topN)
+                .WithParameter("@embedding", embedding)
+                .WithParameter("@searchText", searchText);
+
+            using var streamIterator = container.GetItemQueryStreamIterator(
+                queryDefinition,
+                requestOptions: new QueryRequestOptions { MaxItemCount = topN }
+            );
+
+            var results = new List<System.Text.Json.JsonElement>();
+            while (streamIterator.HasMoreResults && results.Count < topN)
+            {
+                using var response = await streamIterator.ReadNextAsync(cancellationToken);
+                using var stream = response.Content;
+                using var document = await System.Text.Json.JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+                
+                var documents = document.RootElement.GetProperty("Documents");
+                foreach (var doc in documents.EnumerateArray())
+                {
+                    results.Add(doc.Clone());
+                    if (results.Count >= topN) break;
+                }
+            }
+
+            _logger.LogInformation("Hybrid search returned {Count} results", results.Count);
+            return results;
+        }
+        catch (ArgumentException ex)
+        {
+            _logger.LogWarning(ex, "Invalid parameter: {Message}", ex.Message);
+            return new { error = ex.Message };
+        }
+        catch (CosmosException cex)
+        {
+            _logger.LogError(cex, "Cosmos DB error in hybrid search: {StatusCode}", cex.StatusCode);
+            return new { error = cex.Message, statusCode = (int)cex.StatusCode };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error in hybrid search");
             return new { error = ex.Message };
         }
     }

--- a/src/AzureCosmosDB.MCP.Toolkit/Services/McpToolRequestValidator.cs
+++ b/src/AzureCosmosDB.MCP.Toolkit/Services/McpToolRequestValidator.cs
@@ -27,7 +27,7 @@ public sealed class McpToolRequestValidator
                 ["containerId"] = ToolArgumentSchema.String(required: true, maxLength: 256),
                 ["property"] = ToolArgumentSchema.String(required: true, maxLength: 256),
                 ["searchPhrase"] = ToolArgumentSchema.String(required: true, maxLength: 2048),
-                ["n"] = ToolArgumentSchema.Integer(required: true, minValue: 1, maxValue: 20)
+                ["n"] = ToolArgumentSchema.Integer(required: false, minValue: 1, maxValue: 20)
             }),
             ["find_document_by_id"] = new(new Dictionary<string, ToolArgumentSchema>(StringComparer.Ordinal)
             {
@@ -47,7 +47,17 @@ public sealed class McpToolRequestValidator
                 ["searchText"] = ToolArgumentSchema.String(required: true, maxLength: 2048),
                 ["vectorProperty"] = ToolArgumentSchema.String(required: true, maxLength: 256),
                 ["selectProperties"] = ToolArgumentSchema.String(required: true, maxLength: 512),
-                ["topN"] = ToolArgumentSchema.Integer(required: true, minValue: 1, maxValue: 50)
+                ["topN"] = ToolArgumentSchema.Integer(required: false, minValue: 1, maxValue: 50)
+            }),
+            ["hybrid_search"] = new(new Dictionary<string, ToolArgumentSchema>(StringComparer.Ordinal)
+            {
+                ["databaseId"] = ToolArgumentSchema.String(required: true, maxLength: 256),
+                ["containerId"] = ToolArgumentSchema.String(required: true, maxLength: 256),
+                ["searchText"] = ToolArgumentSchema.String(required: true, maxLength: 2048),
+                ["textProperty"] = ToolArgumentSchema.String(required: true, maxLength: 256),
+                ["vectorProperty"] = ToolArgumentSchema.String(required: true, maxLength: 256),
+                ["selectProperties"] = ToolArgumentSchema.String(required: true, maxLength: 512),
+                ["topN"] = ToolArgumentSchema.Integer(required: false, minValue: 1, maxValue: 50)
             })
         };
 

--- a/src/AzureCosmosDB.MCP.Toolkit/wwwroot/index.html
+++ b/src/AzureCosmosDB.MCP.Toolkit/wwwroot/index.html
@@ -336,6 +336,7 @@
                         <option value="find_document_by_id">Find Document by ID</option>
                         <option value="text_search">Text Search</option>
                         <option value="vector_search">Vector Search</option>
+                        <option value="hybrid_search">Hybrid Search</option>
                         <option value="get_approximate_schema">Get Schema</option>
                     </select>
                 </div>
@@ -364,6 +365,11 @@
                     <div class="form-group" id="vectorPropertyField" style="display: none;">
                         <label for="vectorProperty">Vector Property:</label>
                         <input type="text" id="vectorProperty" placeholder="vector or embeddings">
+                    </div>
+                    
+                    <div class="form-group" id="textPropertyField" style="display: none;">
+                        <label for="textProperty">Text Property (full-text index):</label>
+                        <input type="text" id="textProperty" placeholder="content or text">
                     </div>
                     
                     <div class="form-group" id="selectPropertiesField" style="display: none;">
@@ -736,7 +742,13 @@
                     toolParams.searchText = document.getElementById('vectorSearch')?.value || 'machine learning';
                     toolParams.vectorProperty = document.getElementById('vectorProperty')?.value || 'vector';
                     toolParams.selectProperties = document.getElementById('selectProperties')?.value || 'id,title';
-                    toolParams.topN = 5;
+                    toolParams.topN = 10;
+                } else if (tool === 'hybrid_search') {
+                    toolParams.searchText = document.getElementById('vectorSearch')?.value || 'machine learning';
+                    toolParams.textProperty = document.getElementById('textProperty')?.value || 'content';
+                    toolParams.vectorProperty = document.getElementById('vectorProperty')?.value || 'vector';
+                    toolParams.selectProperties = document.getElementById('selectProperties')?.value || 'id,title';
+                    toolParams.topN = 10;
                 } else if (tool === 'list_databases') {
                     toolParams = {}; // No parameters needed
                 } else if (tool === 'list_collections') {
@@ -999,7 +1011,26 @@
                         searchText: searchText,
                         vectorProperty: vectorProp,
                         selectProperties: selectProps,
-                        topN: parseInt(document.getElementById('resultCount').value) || 5
+                        topN: parseInt(document.getElementById('resultCount').value) || 10
+                    };
+                    break;
+                case 'hybrid_search':
+                    const hybridSearchText = document.getElementById('vectorSearch').value.trim();
+                    const hybridTextProp = document.getElementById('textProperty').value.trim();
+                    const hybridVectorProp = document.getElementById('vectorProperty').value.trim();
+                    const hybridSelectProps = document.getElementById('selectProperties').value.trim();
+                    if (!database || !container || !hybridSearchText || !hybridTextProp || !hybridVectorProp || !hybridSelectProps) {
+                        showError('Database ID, Container ID, Search Text, Text Property, Vector Property, and Select Properties are required');
+                        return;
+                    }
+                    toolParams = { 
+                        databaseId: database, 
+                        containerId: container,
+                        searchText: hybridSearchText,
+                        textProperty: hybridTextProp,
+                        vectorProperty: hybridVectorProp,
+                        selectProperties: hybridSelectProps,
+                        topN: parseInt(document.getElementById('resultCount').value) || 10
                     };
                     break;
                 case 'get_approximate_schema':
@@ -1062,6 +1093,7 @@
             document.getElementById('searchPhraseField').style.display = 'none';
             document.getElementById('vectorSearchField').style.display = 'none';
             document.getElementById('vectorPropertyField').style.display = 'none';
+            document.getElementById('textPropertyField').style.display = 'none';
             document.getElementById('selectPropertiesField').style.display = 'none';
             document.getElementById('resultCountField').style.display = 'none';
             
@@ -1104,6 +1136,13 @@
                     document.getElementById('vectorPropertyField').style.display = 'block';
                     document.getElementById('selectPropertiesField').style.display = 'block';
                     // vector_search does NOT show resultCountField - uses fixed value or topN
+                    break;
+                    
+                case 'hybrid_search':
+                    document.getElementById('vectorSearchField').style.display = 'block';
+                    document.getElementById('textPropertyField').style.display = 'block';
+                    document.getElementById('vectorPropertyField').style.display = 'block';
+                    document.getElementById('selectPropertiesField').style.display = 'block';
                     break;
                     
                 case 'get_approximate_schema':

--- a/tests/AzureCosmosDB.MCP.Toolkit.Tests/AzureCosmosDB.MCP.Toolkit.Tests.csproj
+++ b/tests/AzureCosmosDB.MCP.Toolkit.Tests/AzureCosmosDB.MCP.Toolkit.Tests.csproj
@@ -9,15 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit" Version="2.6.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.69" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.16" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AzureCosmosDB.MCP.Toolkit.Tests/CosmosDbToolsTests.cs
+++ b/tests/AzureCosmosDB.MCP.Toolkit.Tests/CosmosDbToolsTests.cs
@@ -84,6 +84,152 @@ public class CosmosDbToolsTests
         errorMessage.Should().Contain("required");
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(51)]
+    [InlineData(-1)]
+    public async Task HybridSearch_Should_Validate_TopN_Parameter(int topN)
+    {
+        // Arrange
+        var mockCosmosClient = new Mock<CosmosClient>();
+        var service = new CosmosDbToolsService(mockCosmosClient.Object, _loggerMock.Object, _configurationMock.Object);
+        
+        // Act
+        var result = await service.HybridSearch("testDb", "testContainer", "search text", "text", "vector", "id,title", topN);
+        
+        // Assert
+        result.Should().NotBeNull();
+        var errorMessage = JsonSerializer.Serialize(result);
+        errorMessage.Should().Contain("must be a whole number between 1 and 50");
+    }
+
+    [Fact]
+    public async Task HybridSearch_Should_Reject_Wildcard_SelectProperties()
+    {
+        // Arrange
+        var mockCosmosClient = new Mock<CosmosClient>();
+        var service = new CosmosDbToolsService(mockCosmosClient.Object, _loggerMock.Object, _configurationMock.Object);
+        
+        // Act
+        var result = await service.HybridSearch("testDb", "testContainer", "search text", "text", "vector", "*", 10);
+        
+        // Assert
+        result.Should().NotBeNull();
+        var errorMessage = JsonSerializer.Serialize(result);
+        errorMessage.Should().Contain("cannot contain '*' wildcard");
+    }
+
+    [Fact]
+    public async Task HybridSearch_Should_Validate_VectorProperty_Name()
+    {
+        // Arrange
+        var mockCosmosClient = new Mock<CosmosClient>();
+        var service = new CosmosDbToolsService(mockCosmosClient.Object, _loggerMock.Object, _configurationMock.Object);
+        
+        // Act
+        var result = await service.HybridSearch("testDb", "testContainer", "search text", "text", "invalid-vector!", "id,title", 10);
+        
+        // Assert
+        result.Should().NotBeNull();
+        var errorMessage = JsonSerializer.Serialize(result);
+        errorMessage.Should().Contain("Invalid vectorProperty name");
+    }
+
+    [Fact]
+    public async Task HybridSearch_Should_Validate_TextProperty_Name()
+    {
+        // Arrange
+        var mockCosmosClient = new Mock<CosmosClient>();
+        var service = new CosmosDbToolsService(mockCosmosClient.Object, _loggerMock.Object, _configurationMock.Object);
+        
+        // Act
+        var result = await service.HybridSearch("testDb", "testContainer", "search text", "invalid-text!", "vector", "id,title", 10);
+        
+        // Assert
+        result.Should().NotBeNull();
+        var errorMessage = JsonSerializer.Serialize(result);
+        errorMessage.Should().Contain("Invalid textProperty name");
+    }
+
+    [Fact]
+    public async Task HybridSearch_Should_Require_Parameters()
+    {
+        // Arrange
+        var mockCosmosClient = new Mock<CosmosClient>();
+        var service = new CosmosDbToolsService(mockCosmosClient.Object, _loggerMock.Object, _configurationMock.Object);
+        
+        // Act
+        var result = await service.HybridSearch("", "", "", "", "", "", 10);
+        
+        // Assert
+        result.Should().NotBeNull();
+        var errorMessage = JsonSerializer.Serialize(result);
+        errorMessage.Should().Contain("required");
+    }
+
+    [Fact]
+    public void McpToolRequestValidator_Should_Accept_Valid_HybridSearch()
+    {
+        // Arrange
+        var validator = new McpToolRequestValidator();
+        using var document = JsonDocument.Parse(
+            """
+            {
+                "name": "hybrid_search",
+                "arguments": {
+                    "databaseId": "db1",
+                    "containerId": "container1",
+                    "searchText": "machine learning",
+                    "textProperty": "content",
+                    "vectorProperty": "embedding",
+                    "selectProperties": "id,title,content",
+                    "topN": 10
+                }
+            }
+            """);
+
+        // Act
+        var result = validator.ValidateToolCall(document.RootElement);
+
+        // Assert
+        result.ToolName.Should().Be("hybrid_search");
+        result.Arguments["databaseId"].Should().Be("db1");
+        result.Arguments["containerId"].Should().Be("container1");
+        result.Arguments["searchText"].Should().Be("machine learning");
+        result.Arguments["textProperty"].Should().Be("content");
+        result.Arguments["vectorProperty"].Should().Be("embedding");
+        result.Arguments["selectProperties"].Should().Be("id,title,content");
+        result.Arguments["topN"].Should().Be(10);
+    }
+
+    [Fact]
+    public void McpToolRequestValidator_Should_Reject_HybridSearch_Missing_TextProperty()
+    {
+        // Arrange
+        var validator = new McpToolRequestValidator();
+        using var document = JsonDocument.Parse(
+            """
+            {
+                "name": "hybrid_search",
+                "arguments": {
+                    "databaseId": "db1",
+                    "containerId": "container1",
+                    "searchText": "machine learning",
+                    "vectorProperty": "embedding",
+                    "selectProperties": "id,title",
+                    "topN": 10
+                }
+            }
+            """);
+
+        // Act
+        Action act = () => validator.ValidateToolCall(document.RootElement);
+
+        // Assert
+        act.Should().Throw<ToolInputValidationException>()
+            .WithMessage("*Missing required argument 'textProperty'*");
+    }
+
         [Fact]
         public void McpToolRequestValidator_Should_Reject_Unknown_Argument_Properties()
         {


### PR DESCRIPTION
- Implemented `hybrid_search` method in `CosmosDbToolsService` to combine vector similarity and full-text keyword search.
- Updated `MCPProtocolController` to include hybrid search endpoint and adjusted parameter handling.
- Enhanced request validation for hybrid search parameters in `McpToolRequestValidator`.
- Updated web UI to support hybrid search input fields and options.
- Added tests for hybrid search functionality, including validation of parameters and error handling.
- Updated dependencies and versioning in project files.